### PR TITLE
chore: add workspace stage vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "prettier.endOfLine": "crlf",
+  "files.eol": "\r\n"
+}


### PR DESCRIPTION
Force anyone to use `CRLF` to add a line break instead of `LF`.