### PR TITLE
fix: dependency cycle of database configurator

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 )
 
 func init() {
-	new(database.DBConf).InitDB().Migrate()
+	new(database.DBConf).InitDB().AutoMigrate()
 }
 
 func main() {

--- a/src/database/mysql.go
+++ b/src/database/mysql.go
@@ -16,11 +16,3 @@ func (DB *DBConf) InitDB() *DBConf {
 	conn, _ := gorm.Open(mysql.Open(dsn), &gorm.Config{})
 	return &DBConf{conn}
 }
-
-func (DB *DBConf) Migrate() {
-	DB.AutoMigrate()
-}
-
-func (DB *DBConf) Demigrate() {
-	DB.Migrator().DropTable()
-}


### PR DESCRIPTION
## Fix Note
Deprecating methods migrator and demigrator in database package. So, to do auto migrate, you can do it in `main.go` directly at `init()` function.

```go
import (
  "clinic-api/src/database"
  "clinic-api/src/models"
  "clinic-api/src/routes"
)

func init() {
  new(database.DBConf).InitDB().AutoMigrate(&models.Test{}) // do migration here, just write the structs
}

```