### PR TITLE
fix(api-spec): elements docs need pre-hosted `api-spec.yml`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ FROM alpine:3.14
 WORKDIR /app
 COPY --from=builder /app/main ./main
 COPY --from=builder /app/public ./public
+COPY --from=builder /app/libs/api-spec ./libs/api-spec
 EXPOSE 8000
 
 CMD ["./main"]

--- a/public/html/api-spec.html
+++ b/public/html/api-spec.html
@@ -11,7 +11,7 @@
   <body>
 
     <elements-api
-      apiDescriptionUrl="https://gist.githubusercontent.com/dhichii/a660ca04401584cba08ed54e4a563965/raw/387b4d3d21ec6f97169d841134c49a858459e82d/clinic-openapi.yml"
+      apiDescriptionUrl="/attachments/api-spec.yml"
       router="hash"
       layout="sidebar"
     />

--- a/src/app/apispec/handlers/handlers.go
+++ b/src/app/apispec/handlers/handlers.go
@@ -10,6 +10,10 @@ func (h *Handler) GetAPISpec(c echo.Context) error {
 	return c.File("public/html/api-spec.html")
 }
 
+func (h *Handler) ServeDocsFile(c echo.Context) error {
+	return c.File("libs/api-spec/api-spec.yml")
+}
+
 func NewHandler() *Handler {
 	return &Handler{}
 }

--- a/src/routes/route.go
+++ b/src/routes/route.go
@@ -12,6 +12,7 @@ func New() *echo.Echo {
 	caHandler := adapters.Init()
 
 	route.GET("/", caHandler.APISpec.GetAPISpec)
+	route.GET("/attachments/api-spec.yml", caHandler.APISpec.ServeDocsFile)
 
 	// login
 	route.POST("/login", caHandler.Account.AttemptLoginHandler)


### PR DESCRIPTION
## Overview
Previously we need to create a gist or something to host the `api-spec.yml`. With this fix, we don't have to host it again while fix or add some docs.

## Tests
- [x] api-spec elemets