### PR TITLE
perf(external-api): change unmarshal to decode

### DIFF
--- a/src/app/icd10/repositories/mysql.go
+++ b/src/app/icd10/repositories/mysql.go
@@ -4,7 +4,6 @@ import (
 	"clinic-api/src/app/icd10"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -18,11 +17,8 @@ func (repo *repository) SearchDataByCode(code string) ([]icd10.Domain, error) {
 		return nil, err
 	}
 
-	defer resp.Body.Close()
-	bodyBytes, _ := ioutil.ReadAll(resp.Body)
-
 	var body Data
-	json.Unmarshal(bodyBytes, &body)
+	json.NewDecoder(resp.Body).Decode(&body)
 
 	return MapToBatchDomain(body.Search), nil
 }

--- a/src/app/medical_record/repositories/mysql.go
+++ b/src/app/medical_record/repositories/mysql.go
@@ -5,7 +5,6 @@ import (
 	"clinic-api/src/utils"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	"gorm.io/gorm"
@@ -33,11 +32,8 @@ func (repo *repository) LookupICD10Data(icd10Code string) (ICD10Description stri
 		return "", err
 	}
 
-	defer resp.Body.Close()
-	bodyBytes, _ := ioutil.ReadAll(resp.Body)
-
 	var body ICDResponse
-	json.Unmarshal(bodyBytes, &body)
+	json.NewDecoder(resp.Body).Decode(&body)
 
 	return body.Description, nil
 }


### PR DESCRIPTION
Using decode is recommended if the data comes from an HTTP request, while unmarshal is used if there is already data stored in memory. It can also simplify the code.