### PR TITLE
feat(medical-record): add patient status

### DIFF
--- a/libs/api-spec/api-spec.yml
+++ b/libs/api-spec/api-spec.yml
@@ -1416,33 +1416,6 @@ components:
           type: string
     MedicalRecord:
       type: object
-      x-examples:
-        example-1:
-          id: 899cc146-3cff-45ce-bc41-32515de0c882
-          patient_satatus: OUTPATIENT
-          symptoms: panas
-          icd10_code: A750
-          icd10_description: Epidemic louse-borne typhus fever due to Rickettsia prowazekii
-          suggestions: ketemu dia
-          patient:
-            id: 516a962a-802f-41f5-a2e0-c315146ad2d4
-            name: capstone
-            nik: '241092980'
-            phone: '825020882'
-            address: 'North Way Street, Antartica Regency'
-            dob: '1997-08-10T07:00:00+07:00'
-            age: 24
-            gender: MALE
-            blood_type: A
-          doctor:
-            id: 8d01edf9-72ca-40b4-a1dd-20b614d597e7
-            name: dr. Capstone X
-            nip: 2015 028171 45
-            sip: SIP.89173.2015.12
-            gender: MALE
-          polyclinic:
-            id: 2
-            name: General
       description: Model of Medical Record.
       properties:
         id:

--- a/libs/api-spec/api-spec.yml
+++ b/libs/api-spec/api-spec.yml
@@ -724,13 +724,13 @@ paths:
             type: string
           in: query
           name: polyclinic
-          description: 'Get by polyclinic id'
-          example: 1
+          description: Get by polyclinic id
+          example: '1'
         - schema:
             type: string
           in: query
           name: from-date
-          description: 'Get from date to latest'
+          description: Get from date to latest
           example: '2021-06-14'
     post:
       summary: Create New Queue
@@ -1416,61 +1416,10 @@ components:
           type: string
     MedicalRecord:
       type: object
-      properties:
-        id:
-          type: string
-        symptoms:
-          type: string
-        icd10_code:
-          type: string
-        icd10_description:
-          type: string
-        suggestions:
-          type: string
-        patient:
-          type: object
-          properties:
-            id:
-              type: string
-            name:
-              type: string
-            nik:
-              type: string
-            phone:
-              type: string
-            address:
-              type: string
-            dob:
-              type: string
-            age:
-              type: integer
-            gender:
-              type: string
-            blood_type:
-              type: string
-        doctor:
-          type: object
-          properties:
-            id:
-              type: string
-            name:
-              type: string
-            nip:
-              type: string
-            sip:
-              type: string
-            gender:
-              type: string
-        polyclinic:
-          type: object
-          properties:
-            id:
-              type: integer
-            name:
-              type: string
       x-examples:
         example-1:
           id: 899cc146-3cff-45ce-bc41-32515de0c882
+          patient_satatus: OUTPATIENT
           symptoms: panas
           icd10_code: A750
           icd10_description: Epidemic louse-borne typhus fever due to Rickettsia prowazekii
@@ -1495,6 +1444,87 @@ components:
             id: 2
             name: General
       description: Model of Medical Record.
+      properties:
+        id:
+          type: string
+          example: 899cc146-3cff-45ce-bc41-32515de0c882
+        patient_status:
+          type: string
+          enum:
+            - OUTPATIENT
+            - REFERRED
+          example: OUTPATIENT
+        symptoms:
+          type: string
+          example: fever
+        icd10_code:
+          type: string
+          example: A750
+        icd10_description:
+          type: string
+          example: Epidemic louse-borne typhus fever due to Rickettsia prowazekii
+        suggestions:
+          type: string
+          example: bed rest 10 days
+        patient:
+          type: object
+          properties:
+            id:
+              type: string
+              example: 516a962a-802f-41f5-a2e0-c315146ad2d4
+            name:
+              type: string
+              example: capstone px
+            nik:
+              type: string
+              example: '3515001111110001'
+            phone:
+              type: string
+              example: 0882000000xx
+            address:
+              type: string
+              example: 'North Way Street, Antartica Regency'
+            dob:
+              type: string
+              example: '1997-08-10'
+            age:
+              type: integer
+              example: 12
+            gender:
+              type: string
+              example: MALE
+            blood_type:
+              type: string
+              example: O+
+        doctor:
+          type: object
+          properties:
+            id:
+              type: string
+              example: 8d01edf9-72ca-40b4-a1dd-20b614d597e7
+            name:
+              type: string
+              example: dr. Capstone X
+            nip:
+              type: string
+              example: 2015 090318 89
+            sip:
+              type: string
+              example: SIP.89173.2015.12
+            gender:
+              type: string
+              enum:
+                - MALE
+                - FEMALE
+        polyclinic:
+          type: object
+          properties:
+            id:
+              type: integer
+              example: 1
+            name:
+              type: string
+              example: General
     Prescription:
       type: object
       properties:
@@ -1516,7 +1546,7 @@ components:
         description:
           type: string
           example: after meals
-      description:  Model of Prescription
+      description: Model of Prescription
     ICD10:
       type: object
       properties:
@@ -2392,6 +2422,8 @@ components:
                 patient_id: 516a962a-802f-41f5-a2e0-c315146ad2d4
                 polyclinic_id: 2
             properties:
+              patient_status:
+                type: string
               symptoms:
                 type: string
                 example: 'fever, sneeze'

--- a/src/app/medical_record/entity.go
+++ b/src/app/medical_record/entity.go
@@ -9,6 +9,7 @@ import (
 
 type Domain struct {
 	ID               uuid.UUID
+	PatientStatus    types.PatientStatusEnum
 	Symptoms         string
 	ICD10Code        string
 	ICD10Description string

--- a/src/app/medical_record/handlers/request/dto.go
+++ b/src/app/medical_record/handlers/request/dto.go
@@ -2,23 +2,26 @@ package request
 
 import (
 	medicalrecord "clinic-api/src/app/medical_record"
+	"clinic-api/src/types"
 
 	"github.com/google/uuid"
 )
 
 type Request struct {
-	Symptoms     string `json:"symptoms"`
-	ICD10Code    string `json:"icd10_code"`
-	Suggestions  string `json:"suggestions"`
-	PatientID    string `json:"patient_id"`
-	PolyclinicID int    `json:"polyclinic_id"`
+	PatientStatus string `json:"patient_status"`
+	Symptoms      string `json:"symptoms"`
+	ICD10Code     string `json:"icd10_code"`
+	Suggestions   string `json:"suggestions"`
+	PatientID     string `json:"patient_id"`
+	PolyclinicID  int    `json:"polyclinic_id"`
 }
 
 func (req *Request) MapToDomain() medicalrecord.Domain {
 	return medicalrecord.Domain{
-		Symptoms:    req.Symptoms,
-		ICD10Code:   req.ICD10Code,
-		Suggestions: req.Suggestions,
+		PatientStatus: types.PatientStatusEnum(req.PatientStatus),
+		Symptoms:      req.Symptoms,
+		ICD10Code:     req.ICD10Code,
+		Suggestions:   req.Suggestions,
 		Patient: medicalrecord.PatientReference{
 			ID: uuid.MustParse(req.PatientID),
 		},

--- a/src/app/medical_record/handlers/response/dto.go
+++ b/src/app/medical_record/handlers/response/dto.go
@@ -9,14 +9,15 @@ import (
 )
 
 type Response struct {
-	ID               uuid.UUID           `json:"id"`
-	Symptoms         string              `json:"symptoms"`
-	ICD10Code        string              `json:"icd10_code"`
-	ICD10Description string              `json:"icd10_description"`
-	Suggestions      string              `json:"suggestions"`
-	Patient          PatientReference    `json:"patient"`
-	Doctor           DoctorReference     `json:"doctor"`
-	Polyclinic       PolyclinicReference `json:"polyclinic"`
+	ID               uuid.UUID               `json:"id"`
+	PatientStatus    types.PatientStatusEnum `json:"patient_status"`
+	Symptoms         string                  `json:"symptoms"`
+	ICD10Code        string                  `json:"icd10_code"`
+	ICD10Description string                  `json:"icd10_description"`
+	Suggestions      string                  `json:"suggestions"`
+	Patient          PatientReference        `json:"patient"`
+	Doctor           DoctorReference         `json:"doctor"`
+	Polyclinic       PolyclinicReference     `json:"polyclinic"`
 }
 
 type PatientReference struct {
@@ -51,6 +52,7 @@ type CreateResponse struct {
 func MapToResponse(domain medicalrecord.Domain) Response {
 	return Response{
 		ID:               domain.ID,
+		PatientStatus:    domain.PatientStatus,
 		Symptoms:         domain.Symptoms,
 		ICD10Code:        domain.ICD10Code,
 		ICD10Description: domain.ICD10Description,

--- a/src/app/medical_record/repositories/mysql.go
+++ b/src/app/medical_record/repositories/mysql.go
@@ -2,10 +2,12 @@ package medicalrecord_repositories
 
 import (
 	medicalrecord "clinic-api/src/app/medical_record"
+	"clinic-api/src/types"
 	"clinic-api/src/utils"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"gorm.io/gorm"
 )
@@ -16,6 +18,11 @@ type repository struct {
 
 // InsertData implements medicalrecord.Repositories
 func (repo *repository) InsertData(domain medicalrecord.Domain) (id string, err error) {
+	// set default value of patient status
+	if strings.ToUpper(string(domain.PatientStatus)) != string(types.OUTPATIENT) ||
+		strings.ToUpper(string(domain.PatientStatus)) != string(types.REFERRED) {
+		domain.PatientStatus = types.OUTPATIENT
+	}
 	record := MapToNewRecord(domain)
 
 	if err := repo.DB.Create(&record).Error; err != nil {

--- a/src/app/medical_record/repositories/record.go
+++ b/src/app/medical_record/repositories/record.go
@@ -13,6 +13,7 @@ import (
 type MedicalRecord struct {
 	gorm.Model
 	ID               uuid.UUID `gorm:"primaryKey;size:191"`
+	PatientStatus    types.PatientStatusEnum
 	Symptoms         string
 	ICD10Code        string
 	ICD10Description string
@@ -56,6 +57,7 @@ type ICDResponse struct {
 func (mr *MedicalRecord) MapToDomain() medicalrecord.Domain {
 	return medicalrecord.Domain{
 		ID:               mr.ID,
+		PatientStatus:    mr.PatientStatus,
 		Symptoms:         mr.Symptoms,
 		ICD10Code:        mr.ICD10Code,
 		ICD10Description: mr.ICD10Description,
@@ -89,6 +91,7 @@ func (mr *MedicalRecord) MapToDomain() medicalrecord.Domain {
 func MapToNewRecord(domain medicalrecord.Domain) MedicalRecord {
 	return MedicalRecord{
 		ID:               uuid.Must(uuid.NewRandom()),
+		PatientStatus:    domain.PatientStatus,
 		Symptoms:         domain.Symptoms,
 		ICD10Code:        domain.ICD10Code,
 		ICD10Description: domain.ICD10Description,

--- a/src/app/medical_record/services/usecases_test.go
+++ b/src/app/medical_record/services/usecases_test.go
@@ -34,6 +34,7 @@ func TestMain(m *testing.M) {
 
 	sampleDomain = medicalrecord.Domain{
 		ID:               sampleMedicalRecordUUID,
+		PatientStatus:    types.OUTPATIENT,
 		Symptoms:         "fever, sneeze",
 		ICD10Code:        "A750",
 		ICD10Description: "Epidemic louse-borne typhus fever due to Rickettsia prowazekii",
@@ -65,10 +66,11 @@ func TestMain(m *testing.M) {
 	sampleDomain.Patient.Age = utils.CountIntervalByYearRoundDown(sampleDomain.Patient.DOB, sampleDomain.CreatedAt)
 
 	sampleNewDomainInput = medicalrecord.Domain{
-		ID:          sampleMedicalRecordUUID,
-		Symptoms:    "fever, sneeze",
-		ICD10Code:   "A750",
-		Suggestions: "total rest 10 days",
+		ID:            sampleMedicalRecordUUID,
+		PatientStatus: types.OUTPATIENT,
+		Symptoms:      "fever, sneeze",
+		ICD10Code:     "A750",
+		Suggestions:   "total rest 10 days",
 		Patient: medicalrecord.PatientReference{
 			ID: samplePatientUUID,
 		},


### PR DESCRIPTION
## Overview
Patient service categorized by queue type. Is patient come referred by other hospital or this hospital outpatient. In order to track, we need to record in medical record where it's created each patient visited a hospital.

## Testing
- [x] Add record
- [x] Add record with no `patient_status` (will be a breaking change if it being restricted)
- [x] Show details of `patient_status`