### PR TITLE
feat(queue): frontend should not to add time manually

### DIFF
--- a/libs/api-spec/api-spec.yml
+++ b/libs/api-spec/api-spec.yml
@@ -2371,10 +2371,6 @@ components:
                   - OUTPATIENT
                   - REFERRED
                 example: OUTPATIENT
-          example:
-            patient_id: 63fb1473-1a8e-4e44-afe5-c74a79260a3e
-            polyclinic_id: 1
-            patient_status: OUTPATIENT
     ExistingQueue:
       content:
         application/json:

--- a/libs/api-spec/api-spec.yml
+++ b/libs/api-spec/api-spec.yml
@@ -2377,16 +2377,9 @@ components:
           schema:
             type: object
             properties:
-              patient_id:
-                type: string
-              polyclinic_id:
-                type: integer
-              patient_status:
-                type: string
-              daily_queue_date:
-                type: string
               service_done_at:
                 type: string
+                example: '2022-07-13 08:41:02'
           example:
             patient_id: 63fb1473-1a8e-4e44-afe5-c74a79260a3e
             polyclinic_id: 1

--- a/libs/api-spec/api-spec.yml
+++ b/libs/api-spec/api-spec.yml
@@ -2361,17 +2361,20 @@ components:
             properties:
               patient_id:
                 type: string
+                example: 516a962a-802f-41f5-a2e0-c315146ad2d4
               polyclinic_id:
                 type: number
+                example: 1
               patient_status:
                 type: string
-              daily_queue_date:
-                type: string
+                enum:
+                  - OUTPATIENT
+                  - REFERRED
+                example: OUTPATIENT
           example:
             patient_id: 63fb1473-1a8e-4e44-afe5-c74a79260a3e
             polyclinic_id: 1
             patient_status: OUTPATIENT
-            daily_queue_date: '2022-06-15'
     ExistingQueue:
       content:
         application/json:

--- a/src/app/queue/handlers/request/dto.go
+++ b/src/app/queue/handlers/request/dto.go
@@ -16,11 +16,7 @@ type NewRequest struct {
 }
 
 type UpdateRequest struct {
-	PatientID      string `json:"patient_id"`
-	PolyclinicID   int    `json:"polyclinic_id"`
-	PatientStatus  string `json:"patient_status"`
-	DailyQueueDate string `json:"daily_queue_date"`
-	ServiceDoneAt  string `json:"service_done_at"`
+	ServiceDoneAt string `json:"service_done_at"`
 }
 
 func (req *NewRequest) MapToDomain() queue.Domain {
@@ -34,10 +30,6 @@ func (req *NewRequest) MapToDomain() queue.Domain {
 
 func (req *UpdateRequest) MapToDomain() queue.Domain {
 	return queue.Domain{
-		PatientID:      uuid.MustParse(req.PatientID),
-		PolyclinicID:   req.PolyclinicID,
-		PatientStatus:  types.PatientStatusEnum(req.PatientStatus),
-		DailyQueueDate: utils.ConvertStringToDate(req.DailyQueueDate),
-		ServiceDoneAt:  utils.ConvertStringToDatetime(req.ServiceDoneAt),
+		ServiceDoneAt: utils.ConvertStringToDatetime(req.ServiceDoneAt),
 	}
 }

--- a/src/app/queue/handlers/request/dto.go
+++ b/src/app/queue/handlers/request/dto.go
@@ -4,15 +4,15 @@ import (
 	"clinic-api/src/app/queue"
 	"clinic-api/src/types"
 	"clinic-api/src/utils"
+	"time"
 
 	"github.com/google/uuid"
 )
 
 type NewRequest struct {
-	PatientID      string `json:"patient_id"`
-	PolyclinicID   int    `json:"polyclinic_id"`
-	PatientStatus  string `json:"patient_status"`
-	DailyQueueDate string `json:"daily_queue_date"`
+	PatientID     string `json:"patient_id"`
+	PolyclinicID  int    `json:"polyclinic_id"`
+	PatientStatus string `json:"patient_status"`
 }
 
 type UpdateRequest struct {
@@ -28,7 +28,7 @@ func (req *NewRequest) MapToDomain() queue.Domain {
 		PatientID:      uuid.MustParse(req.PatientID),
 		PolyclinicID:   req.PolyclinicID,
 		PatientStatus:  types.PatientStatusEnum(req.PatientStatus),
-		DailyQueueDate: utils.ConvertStringToDate(req.DailyQueueDate),
+		DailyQueueDate: utils.ConvertStringToDate(time.Now().Format("2006-01-02")),
 	}
 }
 

--- a/src/app/queue/repositories/mysql.go
+++ b/src/app/queue/repositories/mysql.go
@@ -67,7 +67,9 @@ func (repo *repository) SelectAllData(
 // UpdateByID implements queue.Repositories
 func (repo *repository) UpdateByID(id string, data queue.Domain) error {
 	record := MapToExistingRecord(id, data)
-	alteration := repo.DB.Where("id", id).Updates(&record)
+	alteration := repo.DB.Where("id", id).
+		Omit("id", "patient_id", "daily_queue_date", "patient_status", "daily_queue_number").
+		Updates(&record)
 	if alteration.RowsAffected < 1 && alteration.Error == nil {
 		return errors.New("record not found")
 	}


### PR DESCRIPTION
## Overview
Backend was getting full access to control a new queue creation. Default date of queue creation is today, managed by `time` package.

## Testings
- [x] Add new queue with no `daily_queue_date`
