### PR TITLE
fix(admin, patient): update & deletion always return not found

### DIFF
--- a/src/app/admin/repositories/mysql.go
+++ b/src/app/admin/repositories/mysql.go
@@ -79,7 +79,7 @@ func (repo *repository) UpdateByID(id string, data admin.Domain) (err error) {
 	record := MapToExistingRecord(data)
 	alteration := repo.DB.Model(new(Admin)).Where("user_ID = ?", id).Updates(&record)
 
-	if alteration.RowsAffected == 0 {
+	if alteration.RowsAffected == 0 && alteration.Error == nil {
 		return errors.New("record not found")
 	}
 	return alteration.Error

--- a/src/app/patient/repositories/mysql.go
+++ b/src/app/patient/repositories/mysql.go
@@ -16,7 +16,7 @@ type repository struct {
 func (repo *repository) DeleteByID(id string) error {
 	query := repo.DB.Where("id = ?", id).Delete(new(Patient))
 
-	if query.RowsAffected < 1 {
+	if query.RowsAffected < 1 && query.Error == nil {
 		return errors.New("record not found")
 	}
 	return query.Error
@@ -71,7 +71,7 @@ func (repo *repository) UpdateByID(id string, domain patient.Domain) error {
 	record := MapToExistingRecord(domain)
 	query := repo.DB.Where("id = ?", id).Omit("id").Updates(&record)
 
-	if query.RowsAffected < 1 {
+	if query.RowsAffected < 1 && query.Error == nil {
 		return errors.New("record not found")
 	}
 


### PR DESCRIPTION
This bug will always return `not found` if there is an error while updating and deletion