### PR TITLE
fix(admin): avoid self delete on admin role

### DIFF
--- a/src/app/admin/handlers/handlers.go
+++ b/src/app/admin/handlers/handlers.go
@@ -120,6 +120,13 @@ func (h *Handler) AmendAdminByIDHandler(c echo.Context) error {
 func (h *Handler) RemoveAdminByIDHandler(c echo.Context) error {
 	id := c.Param("id")
 
+	token := utils.GetJwtTokenFromRequest(c)
+	if payload, _ := utils.ExtractClaims(token); payload.Id == id {
+		return utils.CreateEchoResponse(c, http.StatusForbidden, response.ErrorResponse{
+			Reason: "can't self delete",
+		})
+	}
+
 	if err := h.services.RemoveAdminByID(id); err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			return utils.CreateEchoResponse(c, http.StatusNotFound, nil)


### PR DESCRIPTION
## Overview 
Admin has a privilege to remove any account. But, currently they're able to remove theirself.  Since it's removed, they won't able to login again. This PR will be fixed this.

## Testing 
- [x] Test delete "myself"  
  ![image](https://user-images.githubusercontent.com/59078748/179419744-10ff8a56-8c10-4ed7-abae-c30429be4c62.png)  
- [x] Test delete others 
  ![image](https://user-images.githubusercontent.com/59078748/179419772-bfacd9fe-5ed2-4b41-b2c1-03586fe21ab6.png)
