### PR TITLE
perf: change partial update routes method from `PUT` to `PATCH`

### DIFF
--- a/libs/api-spec/api-spec.yml
+++ b/libs/api-spec/api-spec.yml
@@ -417,9 +417,9 @@ paths:
           in: header
           name: Authorization
           description: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NTY5MTUyMjQsImp0aSI6IjhkMDFlZGY5LTcyY2EtNDBiNC1hMWRkLTIwYjYxNGQ1OTdlNyIsIm5hbWUiOiJkci4gQ2Fwc3RvbmUgWCIsIm5pcCI6IjIwMTUgMDI4MTcxIDQ1Iiwicm9sZSI6IkRPQ1RPUiJ9.Nc9UNKO4fspncl0XYEOGIXYyZMfiVenWiS4tP_lf-fo
-    put:
+    patch:
       summary: Update Doctor by ID
-      operationId: put-doctors-id
+      operationId: patch-doctors-id
       responses:
         '204':
           $ref: '#/components/responses/204_NoContent'
@@ -546,9 +546,9 @@ paths:
           in: header
           name: Authorization
           description: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NTY5MTUyMjQsImp0aSI6IjhkMDFlZGY5LTcyY2EtNDBiNC1hMWRkLTIwYjYxNGQ1OTdlNyIsIm5hbWUiOiJkci4gQ2Fwc3RvbmUgWCIsIm5pcCI6IjIwMTUgMDI4MTcxIDQ1Iiwicm9sZSI6IkRPQ1RPUiJ9.Nc9UNKO4fspncl0XYEOGIXYyZMfiVenWiS4tP_lf-fo
-    put:
+    patch:
       summary: Update Nurse by ID
-      operationId: put-nurses-id
+      operationId: patch-nurses-id
       responses:
         '204':
           $ref: '#/components/responses/204_NoContent'
@@ -670,9 +670,9 @@ paths:
           in: header
           name: Authorization
           description: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NTY5MTUyMjQsImp0aSI6IjhkMDFlZGY5LTcyY2EtNDBiNC1hMWRkLTIwYjYxNGQ1OTdlNyIsIm5hbWUiOiJkci4gQ2Fwc3RvbmUgWCIsIm5pcCI6IjIwMTUgMDI4MTcxIDQ1Iiwicm9sZSI6IkRPQ1RPUiJ9.Nc9UNKO4fspncl0XYEOGIXYyZMfiVenWiS4tP_lf-fo
-    put:
+    patch:
       summary: Update Admin by ID
-      operationId: put-admins-id
+      operationId: patch-admins-id
       responses:
         '204':
           $ref: '#/components/responses/204_NoContent'
@@ -782,9 +782,9 @@ paths:
         name: id
         in: path
         required: true
-    put:
+    patch:
       summary: Update Queue by ID
-      operationId: put-queues-id
+      operationId: patch-queues-id
       responses:
         '204':
           $ref: '#/components/responses/204_NoContent'
@@ -932,9 +932,9 @@ paths:
           name: Authorization
           description: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NTY5MTUyMjQsImp0aSI6IjhkMDFlZGY5LTcyY2EtNDBiNC1hMWRkLTIwYjYxNGQ1OTdlNyIsIm5hbWUiOiJkci4gQ2Fwc3RvbmUgWCIsIm5pcCI6IjIwMTUgMDI4MTcxIDQ1Iiwicm9sZSI6IkRPQ1RPUiJ9.Nc9UNKO4fspncl0XYEOGIXYyZMfiVenWiS4tP_lf-fo
           required: true
-    put:
+    patch:
       summary: Medical Record Update by ID Lookup
-      operationId: put-medical-records-id
+      operationId: patch-medical-records-id
       responses:
         '204':
           $ref: '#/components/responses/204_NoContent'

--- a/src/routes/route.go
+++ b/src/routes/route.go
@@ -45,27 +45,27 @@ func New() *echo.Echo {
 	doctor.POST("", caHandler.Doctor.CreateDoctorHandler, middlewares.GrantAdmin)
 	doctor.GET("", caHandler.Doctor.ShowAllDoctorsHandler)
 	doctor.GET("/:id", caHandler.Doctor.ShowDoctorByIDHandler)
-	doctor.PUT("/:id", caHandler.Doctor.AmendDoctorByIDHandler, middlewares.GrantAdmin)
+	doctor.PATCH("/:id", caHandler.Doctor.AmendDoctorByIDHandler, middlewares.GrantAdmin)
 	doctor.DELETE("/:id", caHandler.Doctor.RemoveDoctorByIDHandler, middlewares.GrantAdmin)
 
 	nurse := authenticatedRoute.Group("/nurses")
 	nurse.POST("", caHandler.Nurse.CreateNurseHandler, middlewares.GrantAdmin)
 	nurse.GET("", caHandler.Nurse.ShowAllNursesHandler)
 	nurse.GET("/:id", caHandler.Nurse.ShowNurseByIDHandler)
-	nurse.PUT("/:id", caHandler.Nurse.AmendNurseByIDHandler, middlewares.GrantAdmin)
+	nurse.PATCH("/:id", caHandler.Nurse.AmendNurseByIDHandler, middlewares.GrantAdmin)
 	nurse.DELETE("/:id", caHandler.Nurse.RemoveNurseByIDHandler, middlewares.GrantAdmin)
 
 	admin := authenticatedRoute.Group("/admins", middlewares.GrantAdmin)
 	admin.POST("", caHandler.Admin.CreateAdminHandler)
 	admin.GET("", caHandler.Admin.ShowAllAdminsHandler)
 	admin.GET("/:id", caHandler.Admin.ShowAdminByIDHandler)
-	admin.PUT("/:id", caHandler.Admin.AmendAdminByIDHandler)
+	admin.PATCH("/:id", caHandler.Admin.AmendAdminByIDHandler)
 	admin.DELETE("/:id", caHandler.Admin.RemoveAdminByIDHandler)
 
 	queue := authenticatedRoute.Group("/queues")
 	queue.POST("", caHandler.Queue.CreateQueueHandler, middlewares.GrantAdmin)
 	queue.GET("", caHandler.Queue.ShowAllQueuesHandler)
-	queue.PUT("/:id", caHandler.Queue.AmendQueueByIDHandler)
+	queue.PATCH("/:id", caHandler.Queue.AmendQueueByIDHandler)
 	queue.DELETE("/:id", caHandler.Queue.RemoveQueueByIDHandler, middlewares.GrantAdmin)
 
 	authenticatedRoute.GET("dashboards/:feature", caHandler.Dashboard.ShowTotalHandler)
@@ -76,7 +76,7 @@ func New() *echo.Echo {
 	medicalRecord.GET("/patient/id/:id", caHandler.MedicalRecord.ShowMedicalRecordByPatientIDHandler)
 	medicalRecord.GET("/patient/nik/:nik", caHandler.MedicalRecord.ShowMedicalRecordByPatientNIKHandler)
 	medicalRecord.GET("/:id", caHandler.MedicalRecord.ShowMedicalRecordByIDHandler)
-	medicalRecord.PUT("/:id", caHandler.MedicalRecord.AmendMedicalRecordByIDHandler, middlewares.GrantDoctor)
+	medicalRecord.PATCH("/:id", caHandler.MedicalRecord.AmendMedicalRecordByIDHandler, middlewares.GrantDoctor)
 	medicalRecord.DELETE("/:id", caHandler.MedicalRecord.RemoveMedicalRecordByIDHandler, middlewares.GrantDoctor)
 
 	// prescription


### PR DESCRIPTION
This change the routes method from `PUT` to `PATCH` on a route that only updates some field of data. the PATCH method is a request method for making partial changes to an existing resource, making it a lightweight option to update.